### PR TITLE
Add DockerCon to Conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Also, I'd love it if you've found this Project useful - Could you please click o
 | [JSConf](https://jsconf.com/) | JSConf | 10 |Locally run events driven by passionate individuals dedicated to the community |
 | [GitHub Universe](https://githubuniverse.com/) | GitHub | 10 | Explore the future of software development |
 | [Signal Conf](https://signal.twilio.com/) | Twilio | 10 | Twilio’s Annual Customer & Developer Conference |
+| [DockerCon](https://docker.events.cube365.net/docker/dockercon/) | Docker | 10 | DockerCon is a place for the Docker community to come together and thrive |
 
 ## And Then What?
 | Name | Author | Step | Comments |  
@@ -233,6 +234,7 @@ MIT Licence
 32. [AmieCroteau](https://github.com/amiecroteau)
 33. [Divya247](https://github.com/Divya247)
 34. [yamini27](https://github.com/yamini27)
+35. [Plingooo](https://github.com/Plingooo)
 
 
 


### PR DESCRIPTION
For issue #142

## In this pull request
- [ ]  I am adding a new resource.
- [ ]  I am adding a new step
- [X]  I am providing an edit
- [ ] Removing a resource

## Providing an Edit
* The edit I am providing is to Conferences Section
